### PR TITLE
Clarified docs for PhoneInput

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ A custom class can be passed through the `className` prop.
     <td>defaultCountry</td>
     <td>string</td>
     <td>null</td>
-    <td>Sets the default country</td>
+    <td>Sets the default country (use iso alpha-2 country code e.g 'us', 'gb', 'fr') </td>
   </tr>
   <tr>
     <td>disabled</td>


### PR DESCRIPTION
Made it clearer that one has to use the ISO country codes in defaultCountry for PhoneInput (I had to use the browser debugger to find this)